### PR TITLE
Fix ToGeneralMultiPart method

### DIFF
--- a/GeoDataToolkit/GeoDataToolkit.FGDB/Accessors/Converter/FgdbGeometryConverterExtensions.cs
+++ b/GeoDataToolkit/GeoDataToolkit.FGDB/Accessors/Converter/FgdbGeometryConverterExtensions.cs
@@ -90,7 +90,7 @@ namespace GeoDataToolkit.FGDB.Accessors.Converter
 				var points = linearRing.Vertices;
 				for (var j = partStart; j <= partEnd; j++)
 				{
-					var mapPoint = new GeometryFactory().CreatePoint(multiPart.Points[i].x, multiPart.Points[i].y);
+					var mapPoint = new GeometryFactory().CreatePoint(multiPart.Points[j].x, multiPart.Points[j].y);
 
 					points.Add(mapPoint);
 				}


### PR DESCRIPTION
before: var mapPoint = new GeometryFactory().CreatePoint(multiPart.Points[i].x, multiPart.Points[i].y);
now: var mapPoint = new GeometryFactory().CreatePoint(multiPart.Points[j].x, multiPart.Points[j].y);